### PR TITLE
Make acquireTimeout=0 behavior predictable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add redis-semaphore ioredis
 - `key` - **required**, key for locking resource (final key in redis: `mutex:<key>`)
 - `options` - _optional_
   - `lockTimeout` - _optional_ ms, time after mutex will be auto released (expired)
-  - `acquireTimeout` - _optional_ ms, max timeout for `.acquire()` call
+  - `acquireTimeout` - _optional_ ms, max timeout for `.acquire()` call. If set to 0, will only attempt to acquire lock once
   - `retryInterval` - _optional_ ms, time between acquire attempts if resource locked
   - `refreshInterval` - _optional_ ms, auto-refresh interval; to disable auto-refresh behaviour set `0`
   - `onLockLost` - _optional_ function, called when lock loss is detected due refresh cycle; default onLockLost throws unhandled LostLockError

--- a/src/RedisMutex.ts
+++ b/src/RedisMutex.ts
@@ -1,7 +1,7 @@
 import Redis from 'ioredis'
 
 import { Lock } from './Lock'
-import { acquireMutex } from './mutex/acquire'
+import { acquireMutex, acquireMutexOnce } from './mutex/acquire'
 import { refreshMutex } from './mutex/refresh'
 import { releaseMutex } from './mutex/release'
 import { LockOptions } from './types'
@@ -39,6 +39,9 @@ export default class RedisMutex extends Lock {
   }
 
   protected async _acquire() {
+    if (this._acquireOptions.acquireTimeout === 0) {
+      return await acquireMutexOnce(this._client, this._key, this._acquireOptions)
+    }
     return await acquireMutex(this._client, this._key, this._acquireOptions)
   }
 

--- a/src/mutex/acquire.ts
+++ b/src/mutex/acquire.ts
@@ -33,3 +33,20 @@ export async function acquireMutex(
   debug(key, identifier, 'timeout')
   return false
 }
+
+export async function acquireMutexOnce(
+  client: Redis,
+  key: string,
+  options: Options
+) {
+  const { identifier, lockTimeout } = options
+    debug(key, identifier, 'attempt')
+    const result = await client.set(key, identifier, 'PX', lockTimeout, 'NX')
+    debug('result', typeof result, result)
+    if (result === 'OK') {
+      debug(key, identifier, 'acquired')
+      return true
+    }
+  debug(key, identifier, 'timeout')
+  return false
+}

--- a/test/src/RedisMutex.test.ts
+++ b/test/src/RedisMutex.test.ts
@@ -42,6 +42,16 @@ describe('Mutex', () => {
     expect(mutex.isAcquired).to.be.false
     expect(await client.get('mutex:key')).to.be.eql(null)
   })
+  it('should acquire and release lock with a single attempt', async () => {
+    const mutex = new Mutex(client, 'key', { acquireTimeout: 0 })
+    expect(mutex.isAcquired).to.be.false
+    await mutex.acquire()
+    expect(mutex.isAcquired).to.be.true
+    expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
+    await mutex.release()
+    expect(mutex.isAcquired).to.be.false
+    expect(await client.get('mutex:key')).to.be.eql(null)
+  })
   it('should reject after timeout', async () => {
     const mutex1 = new Mutex(client, 'key', timeoutOptions)
     const mutex2 = new Mutex(client, 'key', timeoutOptions)


### PR DESCRIPTION
Existing behavior of `acquireTimeout=0` is fairly risky - if there is any delay between first and second `Date.now()`, no attempt to establish lock will be made.

This change will ensure that there will be exactly one attempt to obtain lock when acquireTimeout is 0, which is a generally expected behaviour.