### PR TITLE
Expose stopRefresh method

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ async function doSomething() {
 }
 ```
 
+#### Example with temporary refresh
+
+```javascript
+async function doSomething() {
+  const mutex = new Mutex(redisClient, 'lockingResource', {
+    lockTimeout: 120000,
+    refreshInterval: 15000
+  })
+  const lockAcquired = await mutex.tryAcquire()
+  if (!lockAcquired) {
+    return
+  }
+  try {
+    while (mutex.isAcquired) {
+      // critical cycle iteration
+    }
+  } finally {
+    // We want to let lock expire over time after operation is finished 
+    await mutex.stopRefresh()
+  }
+}
+```
+
 ### Semaphore
 
 > See [RedisLabs: Basic counting sempahore](https://redislabs.com/ebook/part-2-core-concepts/chapter-6-application-components-in-redis/6-3-counting-semaphores/6-3-1-building-a-basic-counting-semaphore/)

--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ async function doSomething() {
     return
   }
   try {
-    while (mutex.isAcquired) {
       // critical cycle iteration
-    }
   } finally {
     // We want to let lock expire over time after operation is finished 
     await mutex.stopRefresh()

--- a/src/Lock.ts
+++ b/src/Lock.ts
@@ -54,7 +54,7 @@ export abstract class Lock {
     return this._acquired
   }
 
-  private _startRefresh() {
+  public startRefresh() {
     this._refreshInterval = setInterval(
       this._processRefresh,
       this._refreshTimeInterval
@@ -62,7 +62,7 @@ export abstract class Lock {
     this._refreshInterval.unref()
   }
 
-  private _stopRefresh() {
+  public stopRefresh() {
     if (this._refreshInterval) {
       debug(
         `clear refresh interval ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`
@@ -86,7 +86,7 @@ export abstract class Lock {
       const refreshed = await this._refresh()
       if (!refreshed) {
         this._acquired = false
-        this._stopRefresh()
+        this.stopRefresh()
         const lockLostError = new LostLockError(
           `Lost ${this._kind} for key ${this._key}`
         )
@@ -105,7 +105,7 @@ export abstract class Lock {
     }
     this._acquired = true
     if (this._refreshTimeInterval > 0) {
-      this._startRefresh()
+      this.startRefresh()
     }
   }
 
@@ -117,7 +117,7 @@ export abstract class Lock {
     }
     this._acquired = true
     if (this._refreshTimeInterval > 0) {
-      this._startRefresh()
+      this.startRefresh()
     }
     return true
   }
@@ -127,7 +127,7 @@ export abstract class Lock {
       `release ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`
     )
     if (this._refreshTimeInterval > 0) {
-      this._stopRefresh()
+      this.stopRefresh()
     }
     if (this._acquired) {
       await this._release()

--- a/src/Lock.ts
+++ b/src/Lock.ts
@@ -54,7 +54,7 @@ export abstract class Lock {
     return this._acquired
   }
 
-  public startRefresh() {
+  private _startRefresh() {
     this._refreshInterval = setInterval(
       this._processRefresh,
       this._refreshTimeInterval
@@ -62,7 +62,7 @@ export abstract class Lock {
     this._refreshInterval.unref()
   }
 
-  public stopRefresh() {
+  stopRefresh() {
     if (this._refreshInterval) {
       debug(
         `clear refresh interval ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`
@@ -105,7 +105,7 @@ export abstract class Lock {
     }
     this._acquired = true
     if (this._refreshTimeInterval > 0) {
-      this.startRefresh()
+      this._startRefresh()
     }
   }
 
@@ -117,7 +117,7 @@ export abstract class Lock {
     }
     this._acquired = true
     if (this._refreshTimeInterval > 0) {
-      this.startRefresh()
+      this._startRefresh()
     }
     return true
   }

--- a/test/src/RedisMutex.test.ts
+++ b/test/src/RedisMutex.test.ts
@@ -76,6 +76,23 @@ describe('Mutex', () => {
     await mutex.release()
     expect(await client.get('mutex:key')).to.be.eql(null)
   })
+  it('should stop refreshing lock every refreshInterval ms if stopped', async () => {
+    const mutex = new Mutex(client, 'key', timeoutOptions)
+    await mutex.acquire()
+    mutex.stopRefresh()
+    await delay(100)
+    expect(await client.get('mutex:key')).to.be.eql(null)
+  })
+  it('should restart refreshing lock every refreshInterval ms if stopped and started again', async () => {
+    const mutex = new Mutex(client, 'key', timeoutOptions)
+    await mutex.acquire()
+    mutex.stopRefresh()
+    mutex.startRefresh()
+    await delay(100)
+    expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
+    await mutex.release()
+    expect(await client.get('mutex:key')).to.be.eql(null)
+  })
   it('should re-acquire lock if lock was expired between refreshes, but was not acquired by another instance', async () => {
     const mutex = new Mutex(client, 'key', timeoutOptions)
     await mutex.acquire()

--- a/test/src/RedisMutex.test.ts
+++ b/test/src/RedisMutex.test.ts
@@ -71,7 +71,7 @@ describe('Mutex', () => {
   it('should refresh lock every refreshInterval ms until release', async () => {
     const mutex = new Mutex(client, 'key', timeoutOptions)
     await mutex.acquire()
-    await delay(100)
+    await delay(400)
     expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
     await mutex.release()
     expect(await client.get('mutex:key')).to.be.eql(null)
@@ -88,7 +88,7 @@ describe('Mutex', () => {
     await mutex.acquire()
     mutex.stopRefresh()
     mutex.startRefresh()
-    await delay(100)
+    await delay(400)
     expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
     await mutex.release()
     expect(await client.get('mutex:key')).to.be.eql(null)
@@ -97,7 +97,7 @@ describe('Mutex', () => {
     const mutex = new Mutex(client, 'key', timeoutOptions)
     await mutex.acquire()
     await client.del('mutex:key') // "expired"
-    await delay(100)
+    await delay(400)
     expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
     await mutex.release()
     expect(await client.get('mutex:key')).to.be.eql(null)

--- a/test/src/RedisMutex.test.ts
+++ b/test/src/RedisMutex.test.ts
@@ -80,7 +80,7 @@ describe('Mutex', () => {
     const mutex = new Mutex(client, 'key', timeoutOptions)
     await mutex.acquire()
     mutex.stopRefresh()
-    await delay(100)
+    await delay(400)
     expect(await client.get('mutex:key')).to.be.eql(null)
   })
   it('should restart refreshing lock every refreshInterval ms if stopped and started again', async () => {

--- a/test/src/RedisMutex.test.ts
+++ b/test/src/RedisMutex.test.ts
@@ -83,16 +83,6 @@ describe('Mutex', () => {
     await delay(400)
     expect(await client.get('mutex:key')).to.be.eql(null)
   })
-  it('should restart refreshing lock every refreshInterval ms if stopped and started again', async () => {
-    const mutex = new Mutex(client, 'key', timeoutOptions)
-    await mutex.acquire()
-    mutex.stopRefresh()
-    mutex.startRefresh()
-    await delay(400)
-    expect(await client.get('mutex:key')).to.be.eql(mutex.identifier)
-    await mutex.release()
-    expect(await client.get('mutex:key')).to.be.eql(null)
-  })
   it('should re-acquire lock if lock was expired between refreshes, but was not acquired by another instance', async () => {
     const mutex = new Mutex(client, 'key', timeoutOptions)
     await mutex.acquire()

--- a/test/src/RedisSemaphore.test.ts
+++ b/test/src/RedisSemaphore.test.ts
@@ -77,7 +77,7 @@ describe('Semaphore', () => {
     const semaphore2 = new Semaphore(client, 'key', 2, timeoutOptions)
     await semaphore1.acquire()
     await semaphore2.acquire()
-    await delay(100)
+    await delay(400)
     expect(await client.zrange('semaphore:key', 0, -1)).to.have.members([
       semaphore1.identifier,
       semaphore2.identifier
@@ -87,6 +87,20 @@ describe('Semaphore', () => {
       semaphore2.identifier
     ])
     await semaphore2.release()
+    expect(await client.zcard('semaphore:key')).to.be.eql(0)
+  })
+  it('should stop refreshing lock if stopped', async () => {
+    const semaphore1 = new Semaphore(client, 'key', 2, timeoutOptions)
+    const semaphore2 = new Semaphore(client, 'key', 2, timeoutOptions)
+    await semaphore1.acquire()
+    await semaphore2.acquire()
+    await semaphore1.stopRefresh()
+    await delay(400)
+    expect(await client.zrange('semaphore:key', 0, -1)).to.be.eql([
+      semaphore2.identifier
+    ])
+    await semaphore2.stopRefresh()
+    await delay(400)
     expect(await client.zcard('semaphore:key')).to.be.eql(0)
   })
   it('should acquire maximum LIMIT semaphores', async () => {

--- a/test/src/RedlockMultiSemaphore.test.ts
+++ b/test/src/RedlockMultiSemaphore.test.ts
@@ -151,7 +151,7 @@ describe('RedlockMultiSemaphore', () => {
     )
     await semaphore1.acquire()
     await semaphore2.acquire()
-    await delay(100)
+    await delay(400)
     await expectZRangeAllHaveMembers('semaphore:key', [
       semaphore1.identifier + '_0',
       semaphore1.identifier + '_1',
@@ -160,6 +160,30 @@ describe('RedlockMultiSemaphore', () => {
     await semaphore1.release()
     await expectZRangeAllEql('semaphore:key', [semaphore2.identifier + '_0'])
     await semaphore2.release()
+    await expectZCardAllEql('semaphore:key', 0)
+  })
+  it('should stop refreshing lock if stopped', async () => {
+    const semaphore1 = new RedlockMultiSemaphore(
+      allClients,
+      'key',
+      3,
+      2,
+      timeoutOptions
+    )
+    const semaphore2 = new RedlockMultiSemaphore(
+      allClients,
+      'key',
+      3,
+      1,
+      timeoutOptions
+    )
+    await semaphore1.acquire()
+    await semaphore2.acquire()
+    semaphore1.stopRefresh()
+    await delay(400)
+    await expectZRangeAllEql('semaphore:key', [semaphore2.identifier + '_0'])
+    semaphore2.stopRefresh()
+    await delay(400)
     await expectZCardAllEql('semaphore:key', 0)
   })
   it('should acquire maximum LIMIT semaphores', async () => {

--- a/test/src/RedlockMutex.test.ts
+++ b/test/src/RedlockMutex.test.ts
@@ -63,9 +63,16 @@ describe('RedlockMutex', () => {
   it('should refresh lock every refreshInterval ms until release', async () => {
     const mutex = new RedlockMutex(allClients, 'key', timeoutOptions)
     await mutex.acquire()
-    await delay(100)
+    await delay(400)
     await expectGetAll('mutex:key', mutex.identifier)
     await mutex.release()
+    await expectGetAll('mutex:key', null)
+  })
+  it('should stop refreshing if stopped', async () => {
+    const mutex = new RedlockMutex(allClients, 'key', timeoutOptions)
+    await mutex.acquire()
+    mutex.stopRefresh()
+    await delay(400)
     await expectGetAll('mutex:key', null)
   })
   describe('lost lock case', () => {

--- a/test/src/RedlockSemaphore.test.ts
+++ b/test/src/RedlockSemaphore.test.ts
@@ -118,7 +118,7 @@ describe('RedlockSemaphore', () => {
     )
     await semaphore1.acquire()
     await semaphore2.acquire()
-    await delay(100)
+    await delay(400)
     await expectZRangeAllHaveMembers('semaphore:key', [
       semaphore1.identifier,
       semaphore2.identifier
@@ -126,6 +126,28 @@ describe('RedlockSemaphore', () => {
     await semaphore1.release()
     await expectZRangeAllEql('semaphore:key', [semaphore2.identifier])
     await semaphore2.release()
+    await expectZCardAllEql('semaphore:key', 0)
+  })
+  it('should stop refreshing lock if stopped', async () => {
+    const semaphore1 = new RedlockSemaphore(
+      allClients,
+      'key',
+      2,
+      timeoutOptions
+    )
+    const semaphore2 = new RedlockSemaphore(
+      allClients,
+      'key',
+      2,
+      timeoutOptions
+    )
+    await semaphore1.acquire()
+    await semaphore2.acquire()
+    semaphore1.stopRefresh()
+    await delay(400)
+    await expectZRangeAllEql('semaphore:key', [semaphore2.identifier])
+    semaphore2.stopRefresh()
+    await delay(400)
     await expectZCardAllEql('semaphore:key', 0)
   })
   it('should acquire maximum LIMIT semaphores', async () => {


### PR DESCRIPTION
Use-case for this: sometimes we don't want to release lock after operation was completed immediately, but want to let lock expire over time. Pseudocode example:

```js
const listOfWorkToBeDone = await db.getListOfUnprocessedEntities()
const lock = await mutex.tryAcquireLock(listOfWorkToBeDone[0])
if (lock) {
  // processEntry
}
mutex.stopRefresh()
```

If `stopRefresh` is replaced with `release` here, there is a possibility that job A gets a list of unprocessedEntities after job B already acquired a lock, but _before_ job B gets to commit their processing results, and then job A successfully acquires lock _after_ job B released its lock. Then something might get processed twice.