### PR TITLE
feat: added support for externally acquired id

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface TimeoutOptions {
 }
 
 export interface LockOptions extends TimeoutOptions {
+  externallyAcquiredIdentifier?: string
   onLockLost?: LockLostCallback
 }
 


### PR DESCRIPTION
Added support for "continue" already acquired lock.
Example:
You have `scheduler` code, which publish messages to queue for each task on cron '0 */5 * * * *'
Each task can be processed from 1 to 30 minutes and you don't want publish extra messages to queue for tasks that are already being processed.
With this PR, you can now acquire `schedule-${taskId}` lock in `scheduler` code with `lockTimeout` = 30min and `refreshInterval` = 0, send lock `identifier` in queue message and continue use lock in `handler` code by specifing it in constructor (`externallyAcquiredIdentifier`)

scheduler.ts (singleton)
```typescript
new CronJob('0 */5 * * * *', () => {
  const tasksToProcess = await getAllTasks()
  for (const task of tasksToProcess) {
    const scheduleMutex = new Mutex(redisClient, `schedule-task-${task.id}`, {
      lockTimeout: 30 * 60 * 1000, // 30min
      refreshInterval: 0
    })
    // "at most one" queue message per task
    const acquired = await scheduleMutex.tryAcquire();
    if (acquired) {
      // Now task is locked for scheduling for 30min until processor will release this lock.
      // Releasing *before* or *after* actual processing is depends on BL and is out of scope of this example.
      await queue.publish({ taskId: task.id, scheduleMutexIdentifier: scheduleMutex.identifier })
    } else {
      // task was already scheduled and processor is not released `scheduleMutex` yet
      console.log(`Task ${task.id} was already scheduled. Do nothing.`)
    }
  }
}).start()
```
And then in processor you can do something like this:
```typescript
queue.handle(async message => {
  const { taskId, scheduleMutexIdentifier } = message.data;
  const scheduleMutex = new Mutex(redisClient, `schedule-task-${taskId}`, {
    externallyAcquiredIdentifier: scheduleMutexIdentifier,
  })
  await scheduleMutex.release()

  const mutex = new Mutex(redisClient, `process-task-${taskId}`)
  try {
    // processing code
  } finally {
    await mutex.release()
  }
})
```
or this
```typescript
queue.handle(async message => {
  const { taskId, scheduleMutexIdentifier } = message.data;
  const scheduleMutex = new Mutex(redisClient, `schedule-task-${taskId}`, {
    externallyAcquiredIdentifier: scheduleMutexIdentifier,
    lockTimeout: 15000,
    refreshInterval: 1000
  })

  await scheduleMutex.tryAcquire()
  // now schedule lock (if it still exist in redis) will expire in 15s and refresh every second
  // so if processing code will die next scheduler cron job will add new queue message after 15s, not 30min 

  const mutex = new Mutex(redisClient, `process-task-${taskId}`)
  try {
    // processing code
  } finally {
    await mutex.release()
  }

  await scheduleMutex.release()
})
```
or even this if `scheduler` is the only one source of queue messages
```typescript
queue.handle(async message => {
  const { taskId, scheduleMutexIdentifier } = message.data;
  const mutex = new Mutex(redisClient, `schedule-task-${taskId}`, {
    externallyAcquiredIdentifier: scheduleMutexIdentifier,
    lockTimeout: 15000,
    refreshInterval: 1000
  })
  await mutex.acquire() // will throw LostLockError if message was in queue too long (>30min) AND this is what you want in BL
  try { 
    // processing code
  } finally {
    await mutex.release()
  }
})
```