### PR TITLE
Clarify `acquire` method's signature changed in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@
 ### redis-semaphore@3.0.0
 
 - **Breaking change:** `FairSemaphore` has been removed. Use `Semaphore` instead (has the same "fairness")
+  - the `acquire` method in `Semaphore` no longer returns a boolean. Instead, it throws an error if it cannot acquire, and if it doesn't throw, you can assume it worked.
 - Internal code has been cleaned up
 - Added more test, include synthetic node unsynchroned clocks


### PR DESCRIPTION
Hi,

Our team detected that there are breaking changes coming from an old version (1.x) to 3.1.0+

The CHANGELOG.md mentions about a breaking change, but it says to replace from `FairSemaphore` to `Semaphore` but it doesn't warn that the `acquire` method no longer returns a boolean, and rather, throws when it cannot acquire, and returns nothing.

I think it would be good to add this into the CHANGELOG.md entry, in case other are coming from an old version (like us).

Thank you!

Luis