### PR TITLE
Add update method

### DIFF
--- a/src/RedisMutex.ts
+++ b/src/RedisMutex.ts
@@ -38,6 +38,15 @@ export default class RedisMutex extends Lock {
     )
   }
 
+  protected async _update(newTimeout: number) {
+    return await refreshMutex(
+      this._client,
+      this._key,
+      this._identifier,
+      newTimeout
+    )
+  }
+
   protected async _acquire() {
     return await acquireMutex(this._client, this._key, this._acquireOptions)
   }

--- a/src/RedisSemaphore.ts
+++ b/src/RedisSemaphore.ts
@@ -36,6 +36,18 @@ export default class RedisSemaphore extends RedisMutex {
     )
   }
 
+  protected async _update(newTimeout: number) {
+    return await refreshSemaphore(
+      this._client,
+      this._key,
+      this._limit,
+      {
+        ...this._acquireOptions,
+        lockTimeout: newTimeout
+      }
+    )
+  }
+
   protected async _acquire() {
     return await acquireSemaphore(
       this._client,

--- a/src/RedlockMultiSemaphore.ts
+++ b/src/RedlockMultiSemaphore.ts
@@ -37,6 +37,19 @@ export default class RedlockMultiSemaphore extends RedlockSemaphore {
     )
   }
 
+  protected async _update(newTimeout: number) {
+    return await refreshRedlockMultiSemaphore(
+      this._clients,
+      this._key,
+      this._limit,
+      this._permits,
+      {
+        ...this._acquireOptions,
+        lockTimeout: newTimeout
+      }
+    )
+  }
+
   protected async _acquire() {
     return await acquireRedlockMultiSemaphore(
       this._clients,

--- a/src/RedlockMutex.ts
+++ b/src/RedlockMutex.ts
@@ -43,6 +43,15 @@ export default class RedlockMutex extends Lock {
     )
   }
 
+  protected async _update(newTimeout: number) {
+    return await refreshRedlockMutex(
+      this._clients,
+      this._key,
+      this._identifier,
+      newTimeout
+    )
+  }
+
   protected async _acquire() {
     return await acquireRedlockMutex(
       this._clients,

--- a/src/RedlockSemaphore.ts
+++ b/src/RedlockSemaphore.ts
@@ -36,6 +36,18 @@ export default class RedlockSemaphore extends RedlockMutex {
     )
   }
 
+  protected async _update(newTimeout: number) {
+    return await refreshRedlockSemaphore(
+      this._clients,
+      this._key,
+      this._limit,
+      {
+        ...this._acquireOptions,
+        lockTimeout: newTimeout
+      }
+    )
+  }
+
   protected async _acquire() {
     return await acquireRedlockSemaphore(
       this._clients,


### PR DESCRIPTION
This is useful in case there is a need to dynamically adjust duration of a lock - e. g. to start with a short lock (so that it would expire quickly in case background worker dies), and then set it to be a longer lock (to mark task as complete, and asking noone else to attempt this task until certain time passes).

If this approach is OK, I'll add tests and documentation for it.