### PR TITLE
Build for ES

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "coverage-html": "nyc mocha && nyc report --reporter=html",
     "converalls": "nyc mocha && nyc report --reporter=text-lcov | coveralls",
     "dev": "mocha -w",
-    "build": "yarn build-commonjs",
+    "prepack": "yarn build",
+    "build": "yarn build-commonjs && yarn build-es",
     "build-commonjs": "rm -rf lib && yarn tsc -b tsconfig.build-commonjs.json",
     "build-es": "rm -rf es && yarn tsc -b tsconfig.build-es.json",
     "preversion": "yarn lint && yarn test && yarn build"


### PR DESCRIPTION
## Problem
I am trying to use this package in an ES project but it looks like this package is currently only building for commonjs.

![image](https://user-images.githubusercontent.com/18427051/235151808-87270d2c-81a6-49a7-b39b-bfc14053afdb.png)
![image](https://user-images.githubusercontent.com/18427051/235152092-cde19e09-ab95-4930-b496-31d088b7b3ad.png)

## Fix
I have added the build-es to the build script and I added a prepack to ensure it's always built before we pack & publish.
Would be great if you can merge and publish these changes.