### PR TITLE
fix: Race condition between releasing and refreshing locks

### DIFF
--- a/src/Lock.ts
+++ b/src/Lock.ts
@@ -109,7 +109,7 @@ export abstract class Lock {
       )
       return
     }
-    this._refreshing = false
+    this._refreshing = true
     try {
       debug(
         `refresh ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`

--- a/src/Lock.ts
+++ b/src/Lock.ts
@@ -109,6 +109,7 @@ export abstract class Lock {
       )
       return
     }
+    this._refreshing = false
     try {
       debug(
         `refresh ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`

--- a/src/Lock.ts
+++ b/src/Lock.ts
@@ -1,6 +1,5 @@
 import createDebug from 'debug'
 import * as crypto from 'node:crypto'
-
 import LostLockError from './errors/LostLockError'
 import TimeoutError from './errors/TimeoutError'
 import { defaultOnLockLost, defaultTimeoutOptions } from './misc'
@@ -115,7 +114,13 @@ export abstract class Lock {
         `refresh ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`
       )
       const refreshed = await this._refresh()
-      if (!refreshed && this._acquired) {
+      if (!refreshed) {
+        if (!this._acquired) {
+          debug(
+            `refresh ${this._kind} (key: ${this._key}, identifier: ${this._identifier} failed, but lock was purposefully released`
+          )
+          return
+        }
         this._acquired = false
         this.stopRefresh()
         const lockLostError = new LostLockError(

--- a/test/src/Lock.test.ts
+++ b/test/src/Lock.test.ts
@@ -1,0 +1,37 @@
+import { LockOptions } from '../../src'
+import { Lock } from '../../src/Lock'
+import { delay } from '../../src/utils'
+
+describe('Lock', () => {
+  describe('refresh and release race condition', () => {
+    class TestLock extends Lock {
+      protected _kind = 'test-lock'
+      protected _key: string
+      constructor(key: string, options: LockOptions) {
+        super(options)
+        this._key = key
+      }
+      protected async _refresh(): Promise<boolean> {
+        await delay(200)
+        return false
+      }
+      protected async _acquire(): Promise<boolean> {
+        return true
+      }
+      protected async _release(): Promise<void> {}
+    }
+    it('should not throw LostLock error when refresh started but not finished before release happened', async function () {
+      const lock = new TestLock('key', {
+        lockTimeout: 1000,
+        acquireTimeout: 1000,
+        refreshInterval: 50
+      })
+      try {
+        await lock.acquire()
+        await delay(100)
+      } finally {
+        await lock.release()
+      }
+    })
+  })
+})


### PR DESCRIPTION
Closes #205 

Occasionally, when the timing works out just right, there's a race condition between refreshing a lock and releasing it. This is the code that causes it:

```ts
  async release() {
    debug(
      `release ${this._kind} (key: ${this._key}, identifier: ${this._identifier})`
    )
    if (this._refreshTimeInterval > 0) {
      this.stopRefresh() <---- the refresh interval schedules `_refresh` RIGHT before it's cancelled
    }
    if (this._acquired || this._acquiredExternally) {
      await this._release() <---- the execution of `_release` occurs at the same time, "beating" `_refresh`
      // BOOM, the lock is released, but refresh has still been scheduled (or was already running and was just slower)
      // it fails to refresh because we no longer have the lock
    }
    this._acquired = false
    this._acquiredExternally = false
  }
```

The fix is pretty simple -- just don't throw if `_refresh` fails and the lock is no longer acquired.

A more thorough analysis:

There are basically two cases we can run into here. Either `_refresh` wins, in which case there's no problem, and `_release` can still release. No changes necessary. The other option is that `_release` wins, in which case `_refresh` will throw because it failed to release the lock. As long as `_refresh` checks to see whether we still _have_ the lock before throwing, we can avoid this after-release-refresh-failure.

Reproduction:

```ts
import { Semaphore } from "redis-semaphore";
import Redis from "ioredis";

const client = new Redis();
function getSemaphore() {
  return new Semaphore(client, "asdf", 25, {
    acquireTimeout: 30 * 60 * 1000,
    lockTimeout: 10_000,
    refreshInterval: 10,
  });
}
const transferItem = async (i) => {
  const sema = getSemaphore();
  try {
    await sema.acquire();
    console.log(i);
    await new Promise((resolve) => setTimeout(resolve, 1_000));
    return;
  } finally {
    await sema.release();
  }
};

await Promise.all(Array.from({ length: 500 }).map((_, i) => transferItem(i)));
```

The refresh interval is _super_ short because it makes the error more common, but it _can_ occur at any interval.